### PR TITLE
Version 0.6.0

### DIFF
--- a/Summoners War Statistics Setup/Summoners War Statistics Setup.vdproj
+++ b/Summoners War Statistics Setup/Summoners War Statistics Setup.vdproj
@@ -541,6 +541,11 @@
             "AssemblyAsmDisplayName" = "8:System.Net.Http, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
                 "ScatterAssemblies"
                 {
+                    "_024CA1BC7CE4681E3B38DC03766E28B1"
+                    {
+                    "Name" = "8:System.Net.Http.dll"
+                    "Attributes" = "3:512"
+                    }
                 }
             "SourcePath" = "8:System.Net.Http.dll"
             "TargetName" = "8:"
@@ -587,6 +592,11 @@
             "AssemblyAsmDisplayName" = "8:log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
+                    "_132D483717D63FF91EEB536C88D0B4C9"
+                    {
+                    "Name" = "8:log4net.dll"
+                    "Attributes" = "3:512"
+                    }
                 }
             "SourcePath" = "8:log4net.dll"
             "TargetName" = "8:"
@@ -773,6 +783,11 @@
             "AssemblyAsmDisplayName" = "8:SparkleLibrary, Version=2.7.1.0, Culture=neutral, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
+                    "_36E7C9220B8EF4BCD32BE462ECFACCA7"
+                    {
+                    "Name" = "8:SparkleLibrary.dll"
+                    "Attributes" = "3:512"
+                    }
                 }
             "SourcePath" = "8:SparkleLibrary.dll"
             "TargetName" = "8:"
@@ -939,6 +954,11 @@
             "AssemblyAsmDisplayName" = "8:Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
+                    "_4DA68058A3CE717534F28E58CBF17832"
+                    {
+                    "Name" = "8:Newtonsoft.Json.dll"
+                    "Attributes" = "3:512"
+                    }
                 }
             "SourcePath" = "8:Newtonsoft.Json.dll"
             "TargetName" = "8:"
@@ -1225,6 +1245,11 @@
             "AssemblyAsmDisplayName" = "8:ObjectListView, Version=2.7.1.31255, Culture=neutral, PublicKeyToken=b1c5bf581481bcd4, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
+                    "_821728BA1A561E97AE3C9538D6A01AF0"
+                    {
+                    "Name" = "8:ObjectListView.dll"
+                    "Attributes" = "3:512"
+                    }
                 }
             "SourcePath" = "8:ObjectListView.dll"
             "TargetName" = "8:"
@@ -1431,6 +1456,11 @@
             "AssemblyAsmDisplayName" = "8:ListViewPrinter, Version=2.7.1.31255, Culture=neutral, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
+                    "_9FDECCA1172278888B6A67577D7A063F"
+                    {
+                    "Name" = "8:ListViewPrinter.dll"
+                    "Attributes" = "3:512"
+                    }
                 }
             "SourcePath" = "8:ListViewPrinter.dll"
             "TargetName" = "8:"
@@ -1896,7 +1926,7 @@
         "RemovePreviousVersions" = "11:TRUE"
         "DetectNewerInstalledVersion" = "11:TRUE"
         "InstallAllUsers" = "11:FALSE"
-        "ProductVersion" = "8:0.5.0"
+        "ProductVersion" = "8:0.6.0"
         "Manufacturer" = "8:QuatZo"
         "ARPHELPTELEPHONE" = "8:"
         "ARPHELPLINK" = "8:http://reddit.com/u/quatzo"

--- a/Summoners War Statistics/DimHole/DimHole.Designer.cs
+++ b/Summoners War Statistics/DimHole/DimHole.Designer.cs
@@ -671,7 +671,6 @@
             this.Name = "DimHole";
             this.Size = new System.Drawing.Size(780, 411);
             this.VisibleChanged += new System.EventHandler(this.DimHole_VisibleChanged);
-            this.Resize += new System.EventHandler(this.DimHole_Resize);
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxDimensionalHoleEnergy)).EndInit();
             this.panelHeader.ResumeLayout(false);
             this.panelHeader.PerformLayout();

--- a/Summoners War Statistics/DimHole/DimHole.cs
+++ b/Summoners War Statistics/DimHole/DimHole.cs
@@ -187,7 +187,7 @@ namespace Summoners_War_Statistics
             DimHoleLevelChanged?.Invoke((RadioButton)sender);
         }
 
-        private void DimHole_Resize(object sender, EventArgs e)
+        public void DimHole_Resize(object sender, EventArgs e)
         {
             Resized?.Invoke();
         }

--- a/Summoners War Statistics/DimHole/DimHole.resx
+++ b/Summoners War Statistics/DimHole/DimHole.resx
@@ -120,4 +120,7 @@
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/Summoners War Statistics/DimHole/IDimHoleView.cs
+++ b/Summoners War Statistics/DimHole/IDimHoleView.cs
@@ -41,6 +41,7 @@ namespace Summoners_War_Statistics
         void Init(DimensionHoleInfo dimensionHoleInfo, List<Monster> unitList);
         void Front();
         void ResetOnFail();
+        void DimHole_Resize(object sender, EventArgs e);
         #endregion
     }
 }

--- a/Summoners War Statistics/FormMain.Designer.cs
+++ b/Summoners War Statistics/FormMain.Designer.cs
@@ -33,8 +33,8 @@
             this.openFileDialog = new System.Windows.Forms.OpenFileDialog();
             this.pictureBoxSelectJson = new System.Windows.Forms.PictureBox();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-            this.menu1 = new Summoners_War_Statistics.Menu();
             this.summary1 = new Summoners_War_Statistics.Summary();
+            this.menu1 = new Summoners_War_Statistics.Menu();
             this.dimHole1 = new Summoners_War_Statistics.DimHole();
             this.other1 = new Summoners_War_Statistics.Other();
             this.runes1 = new Summoners_War_Statistics.Runes();
@@ -51,6 +51,7 @@
             // 
             this.pictureBoxSelectJson.Dock = System.Windows.Forms.DockStyle.Top;
             this.pictureBoxSelectJson.Image = global::Summoners_War_Statistics.Properties.Resources.banner_selectjsonfile;
+            this.pictureBoxSelectJson.ImeMode = System.Windows.Forms.ImeMode.NoControl;
             this.pictureBoxSelectJson.Location = new System.Drawing.Point(0, 0);
             this.pictureBoxSelectJson.Name = "pictureBoxSelectJson";
             this.pictureBoxSelectJson.Padding = new System.Windows.Forms.Padding(15, 10, 0, 0);
@@ -66,18 +67,6 @@
             this.toolTip1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(124)))), ((int)(((byte)(0)))));
             this.toolTip1.ToolTipIcon = System.Windows.Forms.ToolTipIcon.Info;
             this.toolTip1.ToolTipTitle = "Help";
-            // 
-            // menu1
-            // 
-            this.menu1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(63)))), ((int)(((byte)(63)))), ((int)(((byte)(63)))));
-            this.menu1.Dock = System.Windows.Forms.DockStyle.Top;
-            this.menu1.IsMouseDown = false;
-            this.menu1.Location = new System.Drawing.Point(0, 70);
-            this.menu1.MouseLocation = new System.Drawing.Point(-1, -1);
-            this.menu1.Name = "menu1";
-            this.menu1.Size = new System.Drawing.Size(800, 80);
-            this.menu1.TabIndex = 12;
-            this.menu1.WindowWidth = 0;
             // 
             // summary1
             // 
@@ -114,6 +103,18 @@
             this.summary1.SummonerSocialPoints = ((ushort)(0));
             this.summary1.TabIndex = 13;
             // 
+            // menu1
+            // 
+            this.menu1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(63)))), ((int)(((byte)(63)))), ((int)(((byte)(63)))));
+            this.menu1.Dock = System.Windows.Forms.DockStyle.Top;
+            this.menu1.IsMouseDown = false;
+            this.menu1.Location = new System.Drawing.Point(0, 70);
+            this.menu1.MouseLocation = new System.Drawing.Point(-1, -1);
+            this.menu1.Name = "menu1";
+            this.menu1.Size = new System.Drawing.Size(800, 80);
+            this.menu1.TabIndex = 12;
+            this.menu1.WindowWidth = 0;
+            // 
             // dimHole1
             // 
             this.dimHole1.AutoScroll = true;
@@ -137,6 +138,9 @@
             // 
             this.other1.AutoScroll = true;
             this.other1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(26)))), ((int)(((byte)(26)))), ((int)(((byte)(26)))));
+            this.other1.DaysToMaxFlags = "Never";
+            this.other1.DaysToMaxTowers = "Never";
+            this.other1.Decorations = null;
             this.other1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.other1.Location = new System.Drawing.Point(0, 0);
             this.other1.Name = "other1";
@@ -200,6 +204,7 @@
             this.guild1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(26)))), ((int)(((byte)(26)))), ((int)(((byte)(26)))));
             this.guild1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.guild1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(124)))), ((int)(((byte)(0)))));
+            this.guild1.GuildActualRanking = "Actual ranking";
             this.guild1.GuildBestRanking = "Best ranking";
             this.guild1.GuildLeaderName = "Leader\'s name";
             this.guild1.GuildMembers = ((byte)(0));
@@ -234,6 +239,8 @@
             this.Name = "FormMain";
             this.Text = "Summoners War Statistics";
             this.Load += new System.EventHandler(this.FormMain_Load);
+            this.ResizeBegin += new System.EventHandler(this.FormMain_ResizeBegin);
+            this.ResizeEnd += new System.EventHandler(this.FormMain_SizeChanged);
             this.Resize += new System.EventHandler(this.FormMain_Resize);
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxSelectJson)).EndInit();
             this.ResumeLayout(false);

--- a/Summoners War Statistics/FormMain.cs
+++ b/Summoners War Statistics/FormMain.cs
@@ -17,6 +17,7 @@ namespace Summoners_War_Statistics
     {
         [DllImport("gdi32.dll")]
         private static extern IntPtr AddFontMemResourceEx(IntPtr pbfont, uint cbfont, IntPtr pdv, [In] ref uint pcFonts);
+        private FormWindowState? LastWindowState = null;
 
         #region Properties
         public FontFamily FF { get; set; }
@@ -179,10 +180,32 @@ namespace Summoners_War_Statistics
 
         private void FormMain_Resize(object sender, EventArgs e)
         {
-            pictureBoxSelectJson.Padding = new Padding((pictureBoxSelectJson.Size.Width - pictureBoxSelectJson.Image.Size.Width) / 2, 10, 0, 0);
-            MenuView.WindowWidth = Size.Width;
-            Refresh();
+            if (WindowState != LastWindowState)
+            {
+                LastWindowState = WindowState;
+                FormMain_SizeChanged(null, EventArgs.Empty);
+            }
+           
         }
         #endregion
+
+        private void FormMain_SizeChanged(object sender, EventArgs e)
+        {
+            pictureBoxSelectJson.Padding = new Padding((pictureBoxSelectJson.Size.Width - pictureBoxSelectJson.Image.Size.Width) / 2, 10, 0, 0);
+            MenuView.WindowWidth = Size.Width;
+
+            if (SummaryViewVisibility) { SummaryView.Summary_Resize(null, EventArgs.Empty); }
+            else if (MonstersViewVisibility) { MonstersView.Monsters_Resize(null, EventArgs.Empty); }
+            else if (RunesViewVisibility) { RunesView.Runes_Resize(null, EventArgs.Empty); }
+            else if (DimHoleViewVisibility) { DimHoleView.DimHole_Resize(null, EventArgs.Empty); }
+            else if (GuildViewVisibility) { GuildView.Guild_Resize(null, EventArgs.Empty); }
+            else if (OtherViewVisibility) { OtherView.Other_Resize(null, EventArgs.Empty); }
+            Refresh();
+        }
+
+        private void FormMain_ResizeBegin(object sender, EventArgs e)
+        {
+            RunesView.FlowPanel.SuspendLayout();
+        }
     }
 }

--- a/Summoners War Statistics/Guild/Guild.Designer.cs
+++ b/Summoners War Statistics/Guild/Guild.Designer.cs
@@ -464,7 +464,6 @@
             this.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(124)))), ((int)(((byte)(0)))));
             this.Name = "Guild";
             this.Size = new System.Drawing.Size(800, 600);
-            this.Resize += new System.EventHandler(this.Guild_Resize);
             this.panelGuildText.ResumeLayout(false);
             this.panelGuildText.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxActualRanking)).EndInit();

--- a/Summoners War Statistics/Guild/Guild.cs
+++ b/Summoners War Statistics/Guild/Guild.cs
@@ -131,8 +131,8 @@ namespace Summoners_War_Statistics
             GuildMembers = GuildMembersMax = GuildMembersDefenses = GuildMembersDefensesMax = 0;
         }
 
-        private void Guild_Resize(object sender, EventArgs e)
-        {
+        public void Guild_Resize(object sender, EventArgs e)
+        { 
             Resized?.Invoke();
         }
         #endregion

--- a/Summoners War Statistics/Guild/Guild.resx
+++ b/Summoners War Statistics/Guild/Guild.resx
@@ -120,4 +120,7 @@
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/Summoners War Statistics/Guild/IGuildView.cs
+++ b/Summoners War Statistics/Guild/IGuildView.cs
@@ -36,6 +36,7 @@ namespace Summoners_War_Statistics
         void Init(GuildMap guild, GuildWarParticipationInfo guildwarParticipationInfo, List<GuildWarMember> guildwarMemberList, List<GuildMemberDefense> guildMemberDefenseList, GuildWarRankingStat guildwarRanking, List<long> siegeDefenses, List<Monster> monsters);
         void Front();
         void ResetOnFail();
+        void Guild_Resize(object sender, EventArgs e);
         #endregion
     }
 }

--- a/Summoners War Statistics/Monsters/IMonstersView.cs
+++ b/Summoners War Statistics/Monsters/IMonstersView.cs
@@ -60,6 +60,7 @@ namespace Summoners_War_Statistics
         void ResetMonstersStats();
         void Front();
         void ResetOnFail();
+        void Monsters_Resize(object sender, EventArgs e);
         #endregion
     }
 }

--- a/Summoners War Statistics/Monsters/Monsters.Designer.cs
+++ b/Summoners War Statistics/Monsters/Monsters.Designer.cs
@@ -862,7 +862,6 @@
             this.Name = "Monsters";
             this.Size = new System.Drawing.Size(780, 411);
             this.VisibleChanged += new System.EventHandler(this.Monsters_VisibleChanged);
-            this.Resize += new System.EventHandler(this.Monsters_Resize);
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxStars6)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxElementalNat5)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxElementalNat5Clock)).EndInit();

--- a/Summoners War Statistics/Monsters/Monsters.cs
+++ b/Summoners War Statistics/Monsters/Monsters.cs
@@ -279,7 +279,7 @@ namespace Summoners_War_Statistics
             MonstersCollectionSummoner = MonstersCollectionWhole = 0;
         }
 
-        private void Monsters_Resize(object sender, EventArgs e)
+        public void Monsters_Resize(object sender, EventArgs e)
         {
             Resized?.Invoke();
         }

--- a/Summoners War Statistics/Other/IOtherView.cs
+++ b/Summoners War Statistics/Other/IOtherView.cs
@@ -41,6 +41,7 @@ namespace Summoners_War_Statistics
         void Init(List<Friend> friendsList, List<Decoration> decorations, GuildWarRankingStat guildWarRankingStat, long arenaRatingId);
         void Front();
         void ResetOnFail();
+        void Other_Resize(object sender, EventArgs e);
         #endregion
 
     }

--- a/Summoners War Statistics/Other/Other.Designer.cs
+++ b/Summoners War Statistics/Other/Other.Designer.cs
@@ -593,7 +593,6 @@
             this.Controls.Add(this.panelFriends);
             this.Name = "Other";
             this.Size = new System.Drawing.Size(780, 411);
-            this.Resize += new System.EventHandler(this.Other_Resize);
             this.panelFriends.ResumeLayout(false);
             this.panelFriends.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.objectListViewFriends)).EndInit();

--- a/Summoners War Statistics/Other/Other.cs
+++ b/Summoners War Statistics/Other/Other.cs
@@ -255,7 +255,7 @@ namespace Summoners_War_Statistics
             comboBoxGuildBattlesWon.SelectedIndex = comboBoxRankingArena.SelectedIndex = comboBoxRankingGuild.SelectedIndex = comboBoxRankingSiege.SelectedIndex = comboBoxSiegeResult1.SelectedIndex = 
                 comboBoxSiegeResult2.SelectedIndex = comboBoxWingsPerDay.SelectedIndex = 0;
         }
-        private void Other_Resize(object sender, EventArgs e)
+        public void Other_Resize(object sender, EventArgs e)
         {
             Resized?.Invoke();
         }

--- a/Summoners War Statistics/Other/Other.resx
+++ b/Summoners War Statistics/Other/Other.resx
@@ -120,4 +120,7 @@
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/Summoners War Statistics/Presenter.cs
+++ b/Summoners War Statistics/Presenter.cs
@@ -154,6 +154,12 @@ namespace Summoners_War_Statistics
                 ResourceManager rm = Resources.ResourceManager;
                 button.Image = (Image)rm.GetObject(resourceName);
             }
+            if (view.SummaryViewVisibility) { view.SummaryView.Summary_Resize(null, EventArgs.Empty); }
+            else if (view.MonstersViewVisibility) { view.MonstersView.Monsters_Resize(null, EventArgs.Empty); }
+            else if (view.RunesViewVisibility) { view.RunesView.Runes_Resize(null, EventArgs.Empty); }
+            else if (view.DimHoleViewVisibility) { view.DimHoleView.DimHole_Resize(null, EventArgs.Empty); }
+            else if (view.GuildViewVisibility) { view.GuildView.Guild_Resize(null, EventArgs.Empty); }
+            else if (view.OtherViewVisibility) { view.OtherView.Other_Resize(null, EventArgs.Empty); }
         }
 
         private void View_SelectFileButtonClicked()

--- a/Summoners War Statistics/Runes/IRunesView.cs
+++ b/Summoners War Statistics/Runes/IRunesView.cs
@@ -52,6 +52,8 @@ namespace Summoners_War_Statistics
 
         List<Rune> RunesList { get; set; }
         Dictionary<long, int> MonstersMasterId { get; set; }
+
+        FlowLayoutPanel FlowPanel { get; set; }
         #endregion
 
         #region Events
@@ -64,6 +66,7 @@ namespace Summoners_War_Statistics
         void Init(List<Rune> runes, Dictionary<long, int> monstersMasterId);
         void Front();
         void ResetOnFail();
+        void Runes_Resize(object sender, EventArgs e);
         #endregion
     }
 }

--- a/Summoners War Statistics/Runes/Runes.Designer.cs
+++ b/Summoners War Statistics/Runes/Runes.Designer.cs
@@ -1329,7 +1329,6 @@
             this.Name = "Runes";
             this.Size = new System.Drawing.Size(780, 411);
             this.VisibleChanged += new System.EventHandler(this.Runes_VisibleChanged);
-            this.Resize += new System.EventHandler(this.Runes_Resize);
             this.panelHeader.ResumeLayout(false);
             this.panelHeader.PerformLayout();
             this.flowLayoutPanelFilters.ResumeLayout(false);

--- a/Summoners War Statistics/Runes/Runes.cs
+++ b/Summoners War Statistics/Runes/Runes.cs
@@ -387,6 +387,15 @@ namespace Summoners_War_Statistics
         public List<Rune> RunesList { get; set; }
         public Dictionary<long, int> MonstersMasterId { get; set; }
         #endregion
+
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public FlowLayoutPanel FlowPanel
+        {
+            get => flowLayoutPanelFilters;
+            set => flowLayoutPanelFilters = value;
+        }
         #endregion
 
         #region Events
@@ -477,17 +486,14 @@ namespace Summoners_War_Statistics
             objectListViewRunes.Items.Clear();
             RunesEfficiencyMax = RunesEfficiencyMean = RunesEfficiencyMedian = RunesEfficiencyMin = RunesEfficiencyStandardDeviation = RunesAmount = RunesMaxed = RunesInventory = 0;
         }
-
         private void comboBox_SelectionChangeCommited(object sender, EventArgs e)
         {
             InitRunes?.Invoke();
         }
-
-        private void Runes_Resize(object sender, EventArgs e)
+        public void Runes_Resize(object sender, EventArgs e)
         {
-
+            Resized?.Invoke();
         }
-
         private void Runes_VisibleChanged(object sender, EventArgs e)
         {
             if(Visible == true)

--- a/Summoners War Statistics/Runes/RunesPresenter.cs
+++ b/Summoners War Statistics/Runes/RunesPresenter.cs
@@ -98,6 +98,7 @@ namespace Summoners_War_Statistics
             //comboBoxRuneAncient               - 55
 
             FlowLayoutPanel flowLayoutPanel = (FlowLayoutPanel)view.Cntrls[37];
+            flowLayoutPanel.ResumeLayout();
             if(flowLayoutPanel.Controls[0].Location.Y != flowLayoutPanel.Controls[flowLayoutPanel.Controls.Count - 1].Location.Y)
             {
                 view.Cntrls[32].Height = (flowLayoutPanel.Controls[0].Height * 2) + 20 + view.Cntrls[0].Height;

--- a/Summoners War Statistics/Summary/ISummaryView.cs
+++ b/Summoners War Statistics/Summary/ISummaryView.cs
@@ -56,6 +56,7 @@ namespace Summoners_War_Statistics
         void Init(Summoner wizardInfo, DimensionHoleInfo dimensionHoleInfo, List<Monster> monstersList, List<long> monstersLockedList, List<Rune> runes, DateTime jsonModificationTime, string country, List<Deck> decks);
         void Front();
         void ResetOnFail();
+        void Summary_Resize(object sender, EventArgs e);
         #endregion
     }
 }

--- a/Summoners War Statistics/Summary/Summary.Designer.cs
+++ b/Summoners War Statistics/Summary/Summary.Designer.cs
@@ -874,7 +874,6 @@
             this.Name = "Summary";
             this.Size = new System.Drawing.Size(784, 431);
             this.Load += new System.EventHandler(this.Summary_Load);
-            this.Resize += new System.EventHandler(this.Summary_Resize);
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxCountry)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxAncientCoins)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxSocialPoints)).EndInit();

--- a/Summoners War Statistics/Summary/Summary.cs
+++ b/Summoners War Statistics/Summary/Summary.cs
@@ -243,7 +243,7 @@ namespace Summoners_War_Statistics
             Resized?.Invoke();
         }
 
-        private void Summary_Resize(object sender, EventArgs e)
+        public void Summary_Resize(object sender, EventArgs e)
         {
             Resized?.Invoke();
         }

--- a/Summoners War Statistics/Summary/Summary.resx
+++ b/Summoners War Statistics/Summary/Summary.resx
@@ -120,4 +120,7 @@
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>


### PR DESCRIPTION
### Changelog

- Fixed Runes Tab being non-resizable
- Optimized Dynamic UI 
  - Now it adapts to the provided resolution AFTER resizing, not in real-time
  - At the current state, it rescales button "Select JSON File", Menu oraz currently active tab
  - This solution greatly increases the speed of rescaling UI
  - Also, user won't see ugly UI while resizing
- Some less important bug fixes